### PR TITLE
Cd and Ls commands were implemented

### DIFF
--- a/src/main/java/ru/ifmo/sdc/cli/Environment.java
+++ b/src/main/java/ru/ifmo/sdc/cli/Environment.java
@@ -7,7 +7,11 @@ import java.util.Map;
  * Environment for save variables values
  */
 public class Environment {
-    private final Map<String, String> variables = new HashMap<>();
+    public Environment(Map<String, String> variables) {
+        this.variables = new HashMap<>(variables);
+    }
+
+    private final Map<String, String> variables;
 
     /**
      * Substitute variables values to string
@@ -46,6 +50,10 @@ public class Environment {
             sb.append(symbol);
         }
         return sb.toString();
+    }
+
+    public String get(final String key) {
+        return variables.getOrDefault(key, "");
     }
 
     /**

--- a/src/main/java/ru/ifmo/sdc/cli/Environment.java
+++ b/src/main/java/ru/ifmo/sdc/cli/Environment.java
@@ -7,11 +7,13 @@ import java.util.Map;
  * Environment for save variables values
  */
 public class Environment {
-    public Environment(Map<String, String> variables) {
+    public Environment(Map<String, String> variables, String userDir) {
         this.variables = new HashMap<>(variables);
+        this.userDir = userDir;
     }
 
     private final Map<String, String> variables;
+    public String userDir;
 
     /**
      * Substitute variables values to string

--- a/src/main/java/ru/ifmo/sdc/cli/Shell.java
+++ b/src/main/java/ru/ifmo/sdc/cli/Shell.java
@@ -49,7 +49,7 @@ public class Shell {
                     System.out.println(prevResult);
                 }
             } catch (CommandLine.ParameterException e) {
-                System.err.println(e.getValue());
+                System.err.println(e.getMessage());
             }
         }
     }

--- a/src/main/java/ru/ifmo/sdc/cli/Shell.java
+++ b/src/main/java/ru/ifmo/sdc/cli/Shell.java
@@ -24,7 +24,7 @@ public class Shell {
      */
     private void run() {
         final Scanner scanner = new Scanner(System.in);
-        final Environment environment = new Environment();
+        final Environment environment = new Environment(System.getenv());
         boolean isAlive = true;
         while (isAlive) {
             System.out.print("$ ");

--- a/src/main/java/ru/ifmo/sdc/cli/commands/CdCommand.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/CdCommand.java
@@ -1,0 +1,35 @@
+package ru.ifmo.sdc.cli.commands;
+
+import picocli.CommandLine;
+import ru.ifmo.sdc.cli.Environment;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Change working directory to first argument or home.
+ */
+public class CdCommand extends Command {
+    @CommandLine.Parameters(index = "1..*")
+    private List<String> params = new ArrayList<>();
+
+    @Override
+    public String execute(final String prevResult, final Environment environment) throws IOException {
+        final Path relativePath = Paths.get(params.isEmpty() ? environment.get("HOME") : params.get(0));
+        final Path path = relativePath.isAbsolute() ?
+                relativePath :
+                Paths.get(environment.get("PWD"), relativePath.toString()).toAbsolutePath();
+        if (!path.toFile().isDirectory()) {
+            System.err.println("cd: " + path + ": No such file or directory");
+            throw new IOException();
+        }
+        environment.put(
+                "PWD",
+                path.toString()
+        );
+        return "";
+    }
+}

--- a/src/main/java/ru/ifmo/sdc/cli/commands/CdCommand.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/CdCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
  * Change working directory to first argument or home.
  */
 public class CdCommand extends Command {
-    @CommandLine.Parameters(index = "1..*")
+    @CommandLine.Parameters(index = "1..1")
     private List<String> params = new ArrayList<>();
 
     @Override
@@ -21,15 +21,12 @@ public class CdCommand extends Command {
         final Path relativePath = Paths.get(params.isEmpty() ? environment.get("HOME") : params.get(0));
         final Path path = relativePath.isAbsolute() ?
                 relativePath :
-                Paths.get(environment.get("PWD"), relativePath.toString()).toAbsolutePath();
+                Paths.get(environment.userDir, relativePath.toString()).toAbsolutePath();
         if (!path.toFile().isDirectory()) {
             System.err.println("cd: " + path + ": No such file or directory");
             throw new IOException();
         }
-        environment.put(
-                "PWD",
-                path.toString()
-        );
+        environment.userDir = path.normalize().toString();
         return "";
     }
 }

--- a/src/main/java/ru/ifmo/sdc/cli/commands/CommandFactory.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/CommandFactory.java
@@ -26,6 +26,10 @@ public class CommandFactory {
             command = new WcCommand();
         } else if (firstToken.equals("cat")) {
             command = new CatCommand();
+        } else if (firstToken.equals("ls")) {
+            command = new LsCommand();
+        } else if (firstToken.equals("cd")) {
+            command = new CdCommand();
         } else if (firstToken.equals("exit")) {
             command = new ExitCommand();
         } else if (firstToken.equals("grep")) {

--- a/src/main/java/ru/ifmo/sdc/cli/commands/LsCommand.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/LsCommand.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 
 /**
  * List directory contents. If args are empty, then list working directory contents.
@@ -18,27 +19,27 @@ public class LsCommand extends Command {
 
     @Override
     public String execute(final String prevResult, final Environment environment) throws IOException {
-        StringBuilder stringBuilder = new StringBuilder();
+        StringJoiner stringBuilder = new StringJoiner("\n");
         if (params.isEmpty()) {
             list(environment, stringBuilder, "");
         } else {
             for (String path : params) {
                 if (params.size() > 1)
-                    stringBuilder.append(path).append('\n');
+                    stringBuilder.add(path);
                 list(environment, stringBuilder, path);
             }
         }
         return stringBuilder.toString();
     }
 
-    private void list(Environment environment, StringBuilder stringBuilder, String path) throws IOException {
-        final File file = Paths.get(environment.get("PWD"), path).toFile();
+    private void list(Environment environment, StringJoiner stringBuilder, String path) throws IOException {
+        final File file = Paths.get(environment.userDir, path).toFile();
         if (file.exists())
             if (file.isDirectory())
                 for (String subpath : file.list())
-                    stringBuilder.append(subpath).append('\n');
+                    stringBuilder.add(subpath);
             else
-                stringBuilder.append(path).append('\n');
+                stringBuilder.add(path);
         else {
             System.err.println("ls: " + path + ": No such file or directory");
             throw new IOException();

--- a/src/main/java/ru/ifmo/sdc/cli/commands/LsCommand.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/LsCommand.java
@@ -1,0 +1,47 @@
+package ru.ifmo.sdc.cli.commands;
+
+import picocli.CommandLine;
+import ru.ifmo.sdc.cli.Environment;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * List directory contents. If args are empty, then list working directory contents.
+ */
+public class LsCommand extends Command {
+    @CommandLine.Parameters(index = "1..*")
+    private List<String> params = new ArrayList<>();
+
+    @Override
+    public String execute(final String prevResult, final Environment environment) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        if (params.isEmpty()) {
+            list(environment, stringBuilder, "");
+        } else {
+            for (String path : params) {
+                if (params.size() > 1)
+                    stringBuilder.append(path).append('\n');
+                list(environment, stringBuilder, path);
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+    private void list(Environment environment, StringBuilder stringBuilder, String path) throws IOException {
+        final File file = Paths.get(environment.get("PWD"), path).toFile();
+        if (file.exists())
+            if (file.isDirectory())
+                for (String subpath : file.list())
+                    stringBuilder.append(subpath).append('\n');
+            else
+                stringBuilder.append(path).append('\n');
+        else {
+            System.err.println("ls: " + path + ": No such file or directory");
+            throw new IOException();
+        }
+    }
+}

--- a/src/main/java/ru/ifmo/sdc/cli/commands/PwdCommand.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/PwdCommand.java
@@ -9,6 +9,6 @@ public class PwdCommand extends Command {
 
     @Override
     public String execute(final String prevResult, final Environment environment) {
-        return environment.get("PWD") + '\n';
+        return environment.userDir + '\n';
     }
 }

--- a/src/main/java/ru/ifmo/sdc/cli/commands/PwdCommand.java
+++ b/src/main/java/ru/ifmo/sdc/cli/commands/PwdCommand.java
@@ -9,6 +9,6 @@ public class PwdCommand extends Command {
 
     @Override
     public String execute(final String prevResult, final Environment environment) {
-        return System.getProperty("user.dir");
+        return environment.get("PWD") + '\n';
     }
 }

--- a/src/test/java/ru/ifmo/sdc/cli/ShellTest.java
+++ b/src/test/java/ru/ifmo/sdc/cli/ShellTest.java
@@ -1,6 +1,7 @@
 package ru.ifmo.sdc.cli;
 
 import org.junit.Test;
+import picocli.CommandLine;
 import ru.ifmo.sdc.cli.commands.Command;
 
 import java.io.BufferedReader;
@@ -35,6 +36,12 @@ public class ShellTest {
         assertEquals(Paths.get(System.getProperty("user.dir"), "src").toString() + '\n', result);
     }
 
+    @Test(expected = CommandLine.UnmatchedArgumentException.class)
+    public void testCdWithTooManyArgs() throws IOException {
+        final String result = executeCommands(Collections.singletonList("cd a b"), Collections.singletonList("pwd"));
+        assertEquals(Paths.get(System.getProperty("user.dir"), "src").toString() + '\n', result);
+    }
+
     @Test
     public void testLsWithoutArgs() throws IOException {
         final String result = executeCommands(Collections.singletonList("ls"));
@@ -44,8 +51,8 @@ public class ShellTest {
     @Test
     public void testLsWithArgs() throws IOException {
         final String result = executeCommands(Collections.singletonList("ls src"));
-        assertTrue(result.contains("test\n"));
-        assertTrue(result.contains("main\n"));
+        assertTrue(result.contains("test"));
+        assertTrue(result.contains("main"));
     }
 
     @Test
@@ -175,7 +182,7 @@ public class ShellTest {
     }
 
     private String executeCommands(final List<String>... pipelinedLines) throws IOException {
-        final Environment environment = new Environment(System.getenv());
+        final Environment environment = new Environment(System.getenv(), System.getProperty("user.dir"));
         String prevResult = "";
         for (List<String> pipelinedLine : pipelinedLines) {
             for (String pipelineCommand : pipelinedLine) {


### PR DESCRIPTION
Неудобства, которые я заметил:

* Команды, работающие с файлами, читают целиком в буфер их содержимое. Это создаст проблемы с гигантскими файлами.
* Пустой `README`. Из-за этого и того, что в тестах список команд пайплайна назывался `lines`, 
я сначала пытался дописать результат `ls` в конец `prevResult`.
* Управление ошибками с помощью `IOException`, который никак не обрабатывается, хотя может быть брошен не из кода CLI и значить что-то важное.

Плюсы:

* Команды было просто реализовать.
* Есть тесты.
* Тесты было просто написать.